### PR TITLE
Add a GetSessionToken method to SnowflakeConnection and expose overrides of Client App ID/Version

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -21,7 +21,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-const (
+var (
 	clientType = "Go"
 )
 
@@ -58,6 +58,16 @@ const (
 	// AuthTypeWorkloadIdentityFederation is to use CSP identity for authentication
 	AuthTypeWorkloadIdentityFederation
 )
+
+// SetClientID overrides the default client app ID ("Go")
+func SetClientAppID(clientID string) {
+	clientType = clientID
+}
+
+// SetClientVersion overrides the default client app version
+func SetClientAppVersion(version string) {
+	SnowflakeGoDriverVersion = version
+}
 
 func (authType AuthType) isOauthNativeFlow() bool {
 	return authType == AuthTypeOAuthAuthorizationCode || authType == AuthTypeOAuthClientCredentials
@@ -612,7 +622,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 	var samlResponse []byte
 	var proofKey []byte
 	var err error
-	//var consentCacheIdToken = true
+	// var consentCacheIdToken = true
 
 	if sc.cfg.Authenticator == AuthTypeExternalBrowser || sc.cfg.Authenticator == AuthTypeOAuthAuthorizationCode || sc.cfg.Authenticator == AuthTypeOAuthClientCredentials {
 		if (runtime.GOOS == "windows" || runtime.GOOS == "darwin") && sc.cfg.ClientStoreTemporaryCredential == configBoolNotSet {

--- a/connection.go
+++ b/connection.go
@@ -521,11 +521,20 @@ func (sc *snowflakeConn) GetQueryStatus(
 // token obtained from a browser sign-in for a session OAuth token
 // this way:
 //
+//	acct := "acme"
 //	tok := "ver:1-hint:21..."
+//	gosnowflake.SetClientAppID("PythonConnector")
+//	gosnowflake.SetClientAppVersion("3.15.0")
+//
+//	params := map[string]*string{}
+//	JSON := "json"
+//	params["PYTHON_CONNECTOR_QUERY_RESULT_FORMAT"] = &JSON
 //	c := &gosnowflake.Config{
-//	  Account:       <account_name>,
-//	  Token:         tok,
-//	  Authenticator: gosnowflake.AuthTypeOAuth,
+//	  Account:          acct,
+//	  Token:            tok,
+//	  Authenticator:    gosnowflake.AuthTypeOAuth,
+//	  KeepSessionAlive: true,
+//	  Params:           params,
 //	}
 //	ctr := gosnowflake.NewConnector(gosnowflake.SnowflakeDriver{}, *c)
 //	conn, err := ctr.Connect(context.Background())

--- a/connection.go
+++ b/connection.go
@@ -9,6 +9,7 @@ import (
 	"database/sql/driver"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -513,6 +514,35 @@ func (sc *snowflakeConn) GetQueryStatus(
 		queryRet.Stats.ScanBytes,
 		queryRet.Stats.ProducedRows,
 	}, nil
+}
+
+// GetSessionToken returns a session token suitable for direct API
+// calls, including SPCS. In particular, you can exchange an OAuth
+// token obtained from a browser sign-in for a session OAuth token
+// this way:
+//
+//	tok := "ver:1-hint:21..."
+//	c := &gosnowflake.Config{
+//	  Account:       <account_name>,
+//	  Token:         tok,
+//	  Authenticator: gosnowflake.AuthTypeOAuth,
+//	}
+//	ctr := gosnowflake.NewConnector(gosnowflake.SnowflakeDriver{}, *c)
+//	conn, err := ctr.Connect(context.Background())
+//	// check error
+//	tokOut, err := conn.(gosnowflake.SnowflakeConnection).GetSessionToken()
+func (sc *snowflakeConn) GetSessionToken() (string, error) {
+	if sc.rest == nil {
+		return "", errors.New("not connected")
+	}
+	if sc.rest.TokenAccessor == nil {
+		return "", errors.New("no token available")
+	}
+	tok, _, _ := sc.rest.TokenAccessor.GetTokens()
+	if tok == "" {
+		return "", errors.New("no token available")
+	}
+	return tok, nil
 }
 
 // QueryArrowStream returns batches which can be queried for their raw arrow

--- a/monitoring.go
+++ b/monitoring.go
@@ -113,6 +113,8 @@ type SnowflakeQueryStatus struct {
 // SnowflakeConnection is a wrapper to snowflakeConn that exposes API functions
 type SnowflakeConnection interface {
 	GetQueryStatus(ctx context.Context, queryID string) (*SnowflakeQueryStatus, error)
+	// Get an OAuth session token, if possible
+	GetSessionToken() (string, error)
 }
 
 // checkQueryStatus returns the status given the query ID. If successful,

--- a/monitoring.go
+++ b/monitoring.go
@@ -113,7 +113,7 @@ type SnowflakeQueryStatus struct {
 // SnowflakeConnection is a wrapper to snowflakeConn that exposes API functions
 type SnowflakeConnection interface {
 	GetQueryStatus(ctx context.Context, queryID string) (*SnowflakeQueryStatus, error)
-	// Get an OAuth session token, if possible
+	// GetSessionToken gets an OAuth session token, if possible
 	GetSessionToken() (string, error)
 }
 
@@ -191,7 +191,7 @@ func (sc *snowflakeConn) checkQueryStatus(
 			QueryID:        qid,
 		}).exceptionTelemetry(sc)
 	}
-	//success
+	// success
 	return &queryRet, nil
 }
 

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package gosnowflake
 
 // SnowflakeGoDriverVersion is the version of Go Snowflake Driver.
-const SnowflakeGoDriverVersion = "1.15.0"
+var SnowflakeGoDriverVersion = "1.15.0"


### PR DESCRIPTION
The intent is to enable token exchange, where the client code has obtained an OAuth token via a browser flow, and now wants a session token to hit an API like SPCS that won't accept an OAuth token.

Unfortunately it seems like the behavior of the token exchange is different depending on the client, so this fork also allows you to change the client app ID and version. (These are sent in the body of the request to `/session/v1/login-request`.)